### PR TITLE
Add TLP color circle to file explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The repo depends on the latest plugin API (obsidian.d.ts) in TypeScript Definiti
 This plugin demonstrates some of the basic functionality the plugin API can do.
 - Adds a ribbon icon, which shows a Notice when clicked.
 - Adds a command "Open Sample Modal" which opens a Modal.
+- Displays a small TLP-colored circle next to each file name.
 - Adds a plugin setting tab to the settings page.
 - Registers a global click event and output 'click' to the console.
 - Registers a global interval which logs 'setInterval' to the console.

--- a/styles.css
+++ b/styles.css
@@ -6,3 +6,12 @@ available in the app when your plugin is enabled.
 If your plugin does not need CSS, delete this file.
 
 */
+
+.tlp-indicator {
+width: 0.6em;
+height: 0.6em;
+border-radius: 50%;
+margin-right: 4px;
+display: inline-block;
+pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- show a small circle with TLP color next to file names
- document circle indicator feature in README
- add styles for TLP indicators

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684bea26fd28832c8d90a814fedbdf4d