### PR TITLE
Clean up TLP plugin indicators and settings flow

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,4 @@
-import { App, Editor, MarkdownView, Modal, Plugin, PluginSettingTab, Setting, TFile } from 'obsidian';
-
-// Remember to rename these classes and interfaces!
+import { App, MarkdownView, Plugin, PluginSettingTab, Setting, TAbstractFile, TFile } from 'obsidian';
 
 interface TlpLevelSetting {
     level: string;
@@ -24,216 +22,242 @@ const DEFAULT_SETTINGS: TlpPluginSettings = {
     ]
 };
 
-export default class TlpPlugin extends Plugin {
-	settings: TlpPluginSettings;
-
-async onload() {
-await this.loadSettings();
-
-    this.initializeTlpIndicators();
-    this.initializeTlpBanner();
-
-
-		// This adds a status bar item to the bottom of the app. Does not work on mobile apps.
-		const statusBarItemEl = this.addStatusBarItem();
-		statusBarItemEl.setText('Status Bar Text');
-
-		// This adds a simple command that can be triggered anywhere
-		this.addCommand({
-			id: 'open-sample-modal-simple',
-			name: 'Open sample modal (simple)',
-			callback: () => {
-				new SampleModal(this.app).open();
-			}
-		});
-		// This adds an editor command that can perform some operation on the current editor instance
-		this.addCommand({
-			id: 'sample-editor-command',
-			name: 'Sample editor command',
-			editorCallback: (editor: Editor, view: MarkdownView) => {
-				console.log(editor.getSelection());
-				editor.replaceSelection('Sample Editor Command');
-			}
-		});
-		// This adds a complex command that can check whether the current state of the app allows execution of the command
-		this.addCommand({
-			id: 'open-sample-modal-complex',
-			name: 'Open sample modal (complex)',
-			checkCallback: (checking: boolean) => {
-				// Conditions to check
-				const markdownView = this.app.workspace.getActiveViewOfType(MarkdownView);
-				if (markdownView) {
-					// If checking is true, we're simply "checking" if the command can be run.
-					// If checking is false, then we want to actually perform the operation.
-					if (!checking) {
-						new SampleModal(this.app).open();
-					}
-
-					// This command will only show up in Command Palette when the check function returns true
-					return true;
-				}
-			}
-		});
-
-                // This adds a settings tab so the user can configure various aspects of the plugin
-                this.addSettingTab(new TlpSettingTab(this.app, this));
-
-		// If the plugin hooks up any global DOM events (on parts of the app that doesn't belong to this plugin)
-		// Using this function will automatically remove the event listener when this plugin is disabled.
-		this.registerDomEvent(document, 'click', (evt: MouseEvent) => {
-			console.log('click', evt);
-		});
-
-		// When registering intervals, this function will automatically clear the interval when the plugin is disabled.
-		this.registerInterval(window.setInterval(() => console.log('setInterval'), 5 * 60 * 1000));
-	}
-
-	onunload() {
-
-	}
-
-	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
-
-async saveSettings() {
-    await this.saveData(this.settings);
-}
-
-private normalizeLevel(value: string): string {
-    return value.trim().replace(/^TLP:/i, '');
-}
-
-private getLevelConfig(level: string): TlpLevelSetting | undefined {
-    const normalized = this.normalizeLevel(level);
-    return this.settings.levels.find(l => l.level.toLowerCase() === normalized.toLowerCase());
-}
-
-private getRawTlp(file: TFile): string | null {
-    const cache = this.app.metadataCache.getFileCache(file);
-    const fm = cache?.frontmatter;
-    const tlp = (fm?.tlp ?? fm?.TLP) as string | undefined;
-    return tlp ?? null;
-}
-
-private getTlpColor(file: TFile): string | null {
-    const cache = this.app.metadataCache.getFileCache(file);
-    const fm = cache?.frontmatter;
-    const tlp = (fm?.tlp ?? fm?.TLP) as string | undefined;
-    if (tlp) {
-        const config = this.getLevelConfig(tlp);
-        if (config) return config.color;
-    }
-    return null;
-}
-
-private updateFileIndicator(file: TFile) {
-const navEls = document.querySelectorAll<HTMLElement>(
-    '.nav-file-title-content'
-);
-navEls.forEach(el => {
-if (el.getAttribute('data-path') === file.path) {
-                let indicator = el.querySelector<HTMLElement>('.tlp-indicator');
-                if (!indicator) {
-                indicator = document.createElement('span');
-                indicator.classList.add('tlp-indicator');
-                el.prepend(indicator);
-                }
-const color = this.getTlpColor(file);
-if (color) {
-indicator.style.backgroundColor = color;
-indicator.style.display = 'inline-block';
-} else {
-indicator.style.display = 'none';
-}
-}
+const cloneDefaultSettings = (): TlpPluginSettings => ({
+    levels: DEFAULT_SETTINGS.levels.map(level => ({ ...level }))
 });
-}
 
-updateAllFileIndicators() {
-this.app.vault.getMarkdownFiles().forEach(f => this.updateFileIndicator(f));
-}
+export default class TlpPlugin extends Plugin {
+    public settings: TlpPluginSettings = cloneDefaultSettings();
 
-private initializeTlpIndicators() {
-this.app.workspace.onLayoutReady(() => this.updateAllFileIndicators());
-this.registerEvent(this.app.metadataCache.on('changed', file => {
-if (file instanceof TFile) this.updateFileIndicator(file);
-}));
-this.registerEvent(this.app.vault.on('rename', file => {
-if (file instanceof TFile) this.updateFileIndicator(file);
-}));
-}
+    async onload(): Promise<void> {
+        await this.loadSettings();
 
-private getTlpLevelName(file: TFile): string | null {
-    const cache = this.app.metadataCache.getFileCache(file);
-    const fm = cache?.frontmatter;
-    const tlp = (fm?.tlp ?? fm?.TLP) as string | undefined;
-    if (!tlp) return null;
-    const config = this.getLevelConfig(tlp);
-    return config ? config.name : tlp.toUpperCase();
-}
+        this.initializeTlpIndicators();
+        this.initializeTlpBanner();
 
-updateBanner(file: TFile | null) {
-const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-if (!view) return;
-let banner = view.contentEl.querySelector<HTMLElement>('.tlp-banner');
-if (!banner) {
-banner = document.createElement('div');
-banner.classList.add('tlp-banner');
-view.contentEl.prepend(banner);
-}
+        this.addSettingTab(new TlpSettingTab(this.app, this));
+    }
+
+    async loadSettings(): Promise<void> {
+        const loaded = (await this.loadData()) as Partial<TlpPluginSettings> | null;
+        if (!loaded) {
+            this.settings = cloneDefaultSettings();
+            return;
+        }
+
+        this.settings = {
+            levels: ((loaded.levels as Partial<TlpLevelSetting>[] | undefined) ?? DEFAULT_SETTINGS.levels).map(
+                (level): TlpLevelSetting => ({
+                    level: level?.level ?? '',
+                    name: level?.name ?? '',
+                    color: level?.color ?? '#ffffff'
+                })
+            )
+        };
+    }
+
+    async saveSettings(): Promise<void> {
+        await this.saveData(this.settings);
+    }
+
+    updateAllFileIndicators(): void {
+        this.app.vault.getMarkdownFiles().forEach(file => this.updateFileIndicator(file));
+    }
+
+    updateBanner(file: TFile | null): void {
+        const view = this.getActiveMarkdownView();
+        if (!view) {
+            return;
+        }
+
+        let banner = view.contentEl.querySelector<HTMLElement>('.tlp-banner');
+        if (!banner) {
+            banner = document.createElement('div');
+            banner.classList.add('tlp-banner');
+            view.contentEl.prepend(banner);
+        }
+
         if (!file) {
             banner.style.display = 'none';
             banner.classList.remove('show');
             return;
         }
-const color = this.getTlpColor(file);
-const levelName = this.getTlpLevelName(file);
-const rawLevel = this.getRawTlp(file);
+
+        const color = this.getTlpColor(file);
+        const levelName = this.getTlpLevelName(file);
+        const rawLevel = this.getRawTlp(file);
+
         if (color && levelName && rawLevel) {
             banner.textContent = levelName;
             banner.setAttribute('data-tlp', rawLevel);
             banner.style.backgroundColor = color;
             banner.style.display = 'block';
             banner.classList.remove('show');
+            // Trigger reflow to restart animation when value changes.
             void banner.offsetWidth;
             banner.classList.add('show');
         } else {
             banner.style.display = 'none';
             banner.classList.remove('show');
         }
-}
+    }
 
-private initializeTlpBanner() {
-this.app.workspace.onLayoutReady(() => {
-this.updateBanner(this.app.workspace.getActiveFile());
-});
-this.registerEvent(this.app.workspace.on('file-open', file => this.updateBanner(file)));
-this.registerEvent(this.app.metadataCache.on('changed', file => {
-const active = this.app.workspace.getActiveFile();
-if (active && file.path === active.path) this.updateBanner(file);
-}));
-}
-}
+    private initializeTlpIndicators(): void {
+        this.app.workspace.onLayoutReady(() => this.updateAllFileIndicators());
 
-class SampleModal extends Modal {
-	constructor(app: App) {
-		super(app);
-	}
+        this.registerEvent(
+            this.app.metadataCache.on('changed', file => {
+                if (file instanceof TFile) {
+                    this.updateFileIndicator(file);
+                }
+            })
+        );
 
-	onOpen() {
-		const {contentEl} = this;
-		contentEl.setText('Woah!');
-	}
+        this.registerEvent(
+            this.app.vault.on('rename', (file: TAbstractFile, oldPath: string) => {
+                if (file instanceof TFile) {
+                    this.removeFileIndicator(oldPath);
+                    this.updateFileIndicator(file);
+                }
+            })
+        );
 
-	onClose() {
-		const {contentEl} = this;
-		contentEl.empty();
-	}
+        this.registerEvent(
+            this.app.vault.on('delete', file => {
+                if (file instanceof TFile) {
+                    this.removeFileIndicator(file.path);
+                }
+            })
+        );
+    }
+
+    private initializeTlpBanner(): void {
+        this.app.workspace.onLayoutReady(() => {
+            this.updateBanner(this.app.workspace.getActiveFile());
+        });
+
+        this.registerEvent(
+            this.app.workspace.on('file-open', file => {
+                this.updateBanner(file);
+            })
+        );
+
+        this.registerEvent(
+            this.app.metadataCache.on('changed', file => {
+                const active = this.app.workspace.getActiveFile();
+                if (active && file.path === active.path) {
+                    this.updateBanner(file);
+                }
+            })
+        );
+
+        this.registerEvent(
+            this.app.vault.on('rename', (file: TAbstractFile) => {
+                const active = this.app.workspace.getActiveFile();
+                if (active && file instanceof TFile && file.path === active.path) {
+                    this.updateBanner(file);
+                }
+            })
+        );
+
+        this.registerEvent(
+            this.app.vault.on('delete', file => {
+                const active = this.app.workspace.getActiveFile();
+                if (active && file instanceof TFile && file.path === active.path) {
+                    this.updateBanner(null);
+                }
+            })
+        );
+    }
+
+    private getActiveMarkdownView(): MarkdownView | null {
+        return this.app.workspace.getActiveViewOfType(MarkdownView);
+    }
+
+    private normalizeLevel(value: string): string {
+        return value.trim().replace(/^TLP:/i, '').toLowerCase();
+    }
+
+    private getLevelConfig(level: string): TlpLevelSetting | undefined {
+        const normalized = this.normalizeLevel(level);
+        return this.settings.levels.find(item => this.normalizeLevel(item.level) === normalized);
+    }
+
+    private getFrontmatter(file: TFile): Record<string, unknown> | undefined {
+        return this.app.metadataCache.getFileCache(file)?.frontmatter ?? undefined;
+    }
+
+    private getRawTlp(file: TFile): string | null {
+        const frontmatter = this.getFrontmatter(file);
+        const value = frontmatter?.tlp ?? frontmatter?.TLP;
+        return typeof value === 'string' ? value : null;
+    }
+
+    private getTlpColor(file: TFile): string | null {
+        const raw = this.getRawTlp(file);
+        if (!raw) {
+            return null;
+        }
+
+        const config = this.getLevelConfig(raw);
+        return config ? config.color : null;
+    }
+
+    private getTlpLevelName(file: TFile): string | null {
+        const raw = this.getRawTlp(file);
+        if (!raw) {
+            return null;
+        }
+
+        const config = this.getLevelConfig(raw);
+        return config ? config.name : raw.toUpperCase();
+    }
+
+    private updateFileIndicator(file: TFile): void {
+        const color = this.getTlpColor(file);
+        const levelName = this.getTlpLevelName(file);
+        const raw = this.getRawTlp(file);
+
+        this.forEachNavElement(file.path, el => {
+            let indicator = el.querySelector<HTMLElement>('.tlp-indicator');
+            if (!indicator) {
+                indicator = document.createElement('span');
+                indicator.classList.add('tlp-indicator');
+                el.prepend(indicator);
+            }
+
+            if (color && raw) {
+                indicator.style.backgroundColor = color;
+                indicator.style.display = 'inline-block';
+                indicator.setAttribute('aria-label', `TLP level ${levelName ?? raw}`);
+                indicator.setAttribute('data-tlp', raw);
+            } else {
+                indicator.style.display = 'none';
+                indicator.removeAttribute('aria-label');
+                indicator.removeAttribute('data-tlp');
+            }
+        });
+    }
+
+    private removeFileIndicator(path: string): void {
+        this.forEachNavElement(path, el => {
+            el.querySelector('.tlp-indicator')?.remove();
+        });
+    }
+
+    private forEachNavElement(path: string, callback: (el: HTMLElement) => void): void {
+        document
+            .querySelectorAll<HTMLElement>('.nav-file-title-content')
+            .forEach(el => {
+                if (el.dataset.path === path) {
+                    callback(el);
+                }
+            });
+    }
 }
 
 class TlpSettingTab extends PluginSettingTab {
-    plugin: TlpPlugin;
+    private plugin: TlpPlugin;
 
     constructor(app: App, plugin: TlpPlugin) {
         super(app, plugin);
@@ -246,63 +270,83 @@ class TlpSettingTab extends PluginSettingTab {
 
         containerEl.createEl('h2', { text: 'TLP Levels' });
 
+        const refreshUi = () => {
+            this.plugin.updateAllFileIndicators();
+            this.plugin.updateBanner(this.app.workspace.getActiveFile());
+        };
+
         this.plugin.settings.levels.forEach((level, index) => {
             const setting = new Setting(containerEl);
-            setting.addText(text => text
-                .setPlaceholder('Level')
-                .setValue(level.level)
-                .onChange(async value => {
-                    level.level = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.updateAllFileIndicators();
-                    this.plugin.updateBanner(this.app.workspace.getActiveFile());
-                }));
-            setting.addText(text => text
-                .setPlaceholder('Display Name')
-                .setValue(level.name)
-                .onChange(async value => {
-                    level.name = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.updateBanner(this.app.workspace.getActiveFile());
-                }));
-            setting.addColorPicker(color => color
-                .setValue(level.color)
-                .onChange(async value => {
-                    level.color = value;
-                    await this.plugin.saveSettings();
-                    this.plugin.updateAllFileIndicators();
-                    this.plugin.updateBanner(this.app.workspace.getActiveFile());
-                }));
-            setting.addExtraButton(btn => btn
-                .setIcon('cross')
-                .setTooltip('Delete')
-                .onClick(async () => {
-                    this.plugin.settings.levels.splice(index, 1);
-                    await this.plugin.saveSettings();
-                    this.display();
-                    this.plugin.updateAllFileIndicators();
-                    this.plugin.updateBanner(this.app.workspace.getActiveFile());
-                }));
+
+            setting.addText(text =>
+                text
+                    .setPlaceholder('Level')
+                    .setValue(level.level)
+                    .onChange(async value => {
+                        level.level = value;
+                        await this.plugin.saveSettings();
+                        refreshUi();
+                    })
+            );
+
+            setting.addText(text =>
+                text
+                    .setPlaceholder('Display Name')
+                    .setValue(level.name)
+                    .onChange(async value => {
+                        level.name = value;
+                        await this.plugin.saveSettings();
+                        refreshUi();
+                    })
+            );
+
+            setting.addColorPicker(color =>
+                color
+                    .setValue(level.color)
+                    .onChange(async value => {
+                        level.color = value;
+                        await this.plugin.saveSettings();
+                        refreshUi();
+                    })
+            );
+
+            setting.addExtraButton(btn =>
+                btn
+                    .setIcon('cross')
+                    .setTooltip('Delete')
+                    .onClick(async () => {
+                        this.plugin.settings.levels.splice(index, 1);
+                        await this.plugin.saveSettings();
+                        this.display();
+                        refreshUi();
+                    })
+            );
         });
 
         new Setting(containerEl)
-            .addButton(btn => btn
-                .setButtonText('Add Level')
-                .onClick(() => {
-                    this.plugin.settings.levels.push({ level: '', name: '', color: '#ffffff' });
-                    this.display();
-                }));
+            .addButton(btn =>
+                btn
+                    .setButtonText('Add Level')
+                    .setCta()
+                    .onClick(async () => {
+                        this.plugin.settings.levels.push({ level: '', name: '', color: '#ffffff' });
+                        await this.plugin.saveSettings();
+                        this.display();
+                        refreshUi();
+                    })
+            );
 
         new Setting(containerEl)
-            .addButton(btn => btn
-                .setButtonText('Reset to Defaults')
-                .setWarning()
-                .onClick(async () => {
-                    this.plugin.settings = JSON.parse(JSON.stringify(DEFAULT_SETTINGS));
-                    await this.plugin.saveSettings();
-                    this.display();
-                    this.plugin.updateAllFileIndicators();
-                    this.plugin.updateBanner(this.app.workspace.getActiveFile());
-                }));
+            .addButton(btn =>
+                btn
+                    .setButtonText('Reset to Defaults')
+                    .setWarning()
+                    .onClick(async () => {
+                        this.plugin.settings = cloneDefaultSettings();
+                        await this.plugin.saveSettings();
+                        this.display();
+                        refreshUi();
+                    })
+            );
     }
 }


### PR DESCRIPTION
## Summary
- remove template sample commands and focus the plugin on TLP indicator and banner behaviour
- improve indicator updates across file lifecycle events and add safer settings persistence helpers
- refresh the settings tab actions to immediately persist changes and refresh UI elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6901db914640832c82a8e09c0c7d253a